### PR TITLE
remove incremental materialization from user stitching

### DIFF
--- a/models/sessionization/segment_web_sessions__stitched.sql
+++ b/models/sessionization/segment_web_sessions__stitched.sql
@@ -1,28 +1,15 @@
 {{ config(
-    materialized = 'incremental',
-    unique_key = 'session_id',
-    sort = 'session_start_tstamp',
     partition_by = {'field': 'session_start_tstamp', 'data_type': 'timestamp', 'granularity': var('segment_bigquery_partition_granularity')},
     dist = 'session_id',
     cluster_by = 'session_id'
     )}}
 
 with sessions as (
-
     select * from {{ref('segment_web_sessions__initial')}}
-
-    {% if is_incremental() %}
-    {{
-        generate_sessionization_incremental_filter( this, 'session_start_tstamp', 'session_start_tstamp', '>' )
-    }}
-    {% endif %}
-
 ),
 
 id_stitching as (
-
     select * from {{ref('segment_web_user_stitching')}}
-
 ),
 
 joined as (


### PR DESCRIPTION
## Description & motivation
Removed incremental configuration from user stitching. We need all the users session to properly create the blended_user_id when an user gets identified.
-->

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
